### PR TITLE
Add new line and other characters (hex: 09 - 13) to ascii validator

### DIFF
--- a/Sources/Validation/Validators/IsASCII.swift
+++ b/Sources/Validation/Validators/IsASCII.swift
@@ -14,7 +14,7 @@ public struct IsASCII: Validator {
     public func validate(_ data: ValidationData) throws {
         switch data {
         case .string(let s):
-            guard s.range(of: "^[ -~]+$", options: [.regularExpression, .caseInsensitive]) != nil else {
+            guard s.range(of: "^[\\x09-\\x0d -~]+$", options: [.regularExpression, .caseInsensitive]) != nil else {
                 throw BasicValidationError("is not ASCII")
             }
         default:

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -9,7 +9,10 @@ class ValidationTests: XCTestCase {
     }
 
     func testASCII() throws {
-        try IsASCII().validate(.string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"))
+        try IsASCII().validate(.string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"))
+        try IsASCII().validate(.string("\n\r\t"))
+        try IsASCII().validate(.string(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"))
+
         XCTAssertThrowsError(try IsASCII().validate(.string("ABCDEFGHIJKLMNOPQR🤠STUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"))) {
             XCTAssert($0 is ValidationError)
         }


### PR DESCRIPTION
This PR reflects issue on main vapor repository: https://github.com/vapor/vapor/issues/1364