### PR TITLE
Add phone validator for multiple formats

### DIFF
--- a/Sources/Validation/Validators/PhoneValidator.swift
+++ b/Sources/Validation/Validators/PhoneValidator.swift
@@ -36,10 +36,14 @@ private extension PhoneFormat {
 }
 
 public enum PhoneType {
-    /// Uses country code and always adds an empty space after. Example: `1 (239)555-7777`.
+
+    public typealias CustomRegex = () -> String
+    /// Uses country code and always adds an empty space after. Example: `1 (239)555-7777`. Follows USA/Canada standards.
     case useCountryCode(PhoneFormat)
     /// `PhoneFormat`
     case useSimple(PhoneFormat)
+    /// Use a custom regex for phone numbers that don't follow USA/Canada standards. (i.e. Australia, China, etc...)
+    case useCustomRegex(CustomRegex)
 
     var regex: String {
         switch self {
@@ -47,6 +51,8 @@ public enum PhoneType {
             return "\(countryCodeRegex) \(format.regex)"
         case .useSimple(let format):
             return format.regex
+        case .useCustomRegex(let customRegex):
+            return customRegex()
         }
     }
 }

--- a/Sources/Validation/Validators/PhoneValidator.swift
+++ b/Sources/Validation/Validators/PhoneValidator.swift
@@ -1,4 +1,9 @@
 
+/// Describes the validation of the area code and the digits after the area code.
+/// Supports the following types:
+/// - **plain**: Only uses numbers. Example: `2397777777`
+/// - **dashWithParenthesis**: Uses Dash and Parenthesis. Example: `(239)777-7777`
+/// - **dashOnly**: Only uses Dashes. Example: `239-777-7777`
 public enum PhoneFormat {
     /// Only uses numbers. Example: `2397777777`
     case plain
@@ -35,6 +40,12 @@ private extension PhoneFormat {
     }
 }
 
+/// Describes the phone type to validate against.
+/// This doesn't take into consideration the area code or the digits after the area code (**1** (xxx)xxx-xxxx). The validation for these is set by `PhoneFormat`.
+/// Supports the following types:
+/// - **useCountryCode**: Will validate that the phone number have the country code `1 (xxx)xxx-xxxx`
+/// - **useSimple**: Only validates the area code and phone number.
+/// - **useCustomRegex**: Will validate against a custom regex passed in as a parameter. This option should be use when validating phone numbers that don't follow USA/Canada standards. (i.e. Australia, China, etc...)
 public enum PhoneType {
 
     public typealias CustomRegex = () -> String

--- a/Sources/Validation/Validators/PhoneValidator.swift
+++ b/Sources/Validation/Validators/PhoneValidator.swift
@@ -1,18 +1,18 @@
 
 public enum PhoneFormat {
-    /// Example: `2397777777`
+    /// Only uses numbers. Example: `2397777777`
     case plain
-    /// Example: `(239)777-7777`
+    /// Uses Dash and Parenthesis. Example: `(239)777-7777`
     case dashWithParenthesis
-    /// Example: `239-777-7777`
+    /// Only uses Dashes. Example: `239-777-7777`
     case dashOnly
 
     var regex: String {
         switch self {
         case .plain:
-            return simpleRegex
+            return plainRegex
         case .dashWithParenthesis:
-            return parenthesisWithDashRegex
+            return dashWithParenthesisRegex
         case .dashOnly:
             return onlyDashRegex
         }
@@ -22,11 +22,11 @@ public enum PhoneFormat {
 // MARK: PhoneFormat Regex
 private extension PhoneFormat {
 
-    var simpleRegex: String {
+    var plainRegex: String {
         return "[0-9]{3}[0-9]{3}[0-9]{4}$"
     }
 
-    var parenthesisWithDashRegex: String {
+    var dashWithParenthesisRegex: String {
         return "\\([0-9]{3}\\)[0-9]{3}-[0-9]{4}$"
     }
 
@@ -36,17 +36,16 @@ private extension PhoneFormat {
 }
 
 public enum PhoneType {
-    /// +1 `PhoneFormat`
-    case prefix(PhoneFormat)
+    /// Uses country code and always adds an empty space after. Example: `1 (239)555-7777`.
+    case useCountryCode(PhoneFormat)
     /// `PhoneFormat`
-    case simple(PhoneFormat)
+    case useSimple(PhoneFormat)
 
     var regex: String {
         switch self {
-        case .prefix(let format):
-            return format == .dashOnly ?
-                "\(prefixRegex)-\(format.regex)" : "\(prefixRegex)\(format.regex)"
-        case .simple(let format):
+        case .useCountryCode(let format):
+            return "\(countryCodeRegex) \(format.regex)"
+        case .useSimple(let format):
             return format.regex
         }
     }
@@ -54,7 +53,7 @@ public enum PhoneType {
 
 private extension PhoneType {
 
-    var prefixRegex: String {
+    var countryCodeRegex: String {
         return "[0-9]{1,4}"
     }
 }

--- a/Sources/Validation/Validators/PhoneValidator.swift
+++ b/Sources/Validation/Validators/PhoneValidator.swift
@@ -1,0 +1,85 @@
+
+public enum PhoneFormat {
+    /// Example: `2397777777`
+    case plain
+    /// Example: `(239)777-7777`
+    case dashWithParenthesis
+    /// Example: `239-777-7777`
+    case dashOnly
+
+    var regex: String {
+        switch self {
+        case .plain:
+            return simpleRegex
+        case .dashWithParenthesis:
+            return parenthesisWithDashRegex
+        case .dashOnly:
+            return onlyDashRegex
+        }
+    }
+}
+
+// MARK: PhoneFormat Regex
+private extension PhoneFormat {
+
+    var simpleRegex: String {
+        return "[0-9]{3}[0-9]{3}[0-9]{4}$"
+    }
+
+    var parenthesisWithDashRegex: String {
+        return "\\([0-9]{3}\\)[0-9]{3}-[0-9]{4}$"
+    }
+
+    var onlyDashRegex: String {
+        return "[0-9]{3}-[0-9]{3}-[0-9]{4}$"
+    }
+}
+
+public enum PhoneType {
+    /// +1 `PhoneFormat`
+    case prefix(PhoneFormat)
+    /// `PhoneFormat`
+    case simple(PhoneFormat)
+
+    var regex: String {
+        switch self {
+        case .prefix(let format):
+            return format == .dashOnly ?
+                "\(prefixRegex)-\(format.regex)" : "\(prefixRegex)\(format.regex)"
+        case .simple(let format):
+            return format.regex
+        }
+    }
+}
+
+private extension PhoneType {
+
+    var prefixRegex: String {
+        return "[0-9]{1,4}"
+    }
+}
+
+public extension Validator where T == String {
+    /// Validates whether a `String` is a valid phone format.
+    public static func phone(type: PhoneType) -> Validator<T> {
+        return PhoneValidator(type: type).validator()
+    }
+}
+
+private struct PhoneValidator: ValidatorType {
+
+    let type: PhoneType
+
+    public var validatorReadable: String {
+        return "a valid phone number"
+    }
+
+    /// Validates phone format as follows (123)456-7890
+    public func validate(_ s: String) throws {
+        guard let range = s.range(of: type.regex, options: [.regularExpression, .caseInsensitive]),
+            range.lowerBound == s.startIndex && range.upperBound == s.endIndex
+            else {
+                throw BasicValidationError("is not a valid phone format")
+        }
+    }
+}

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class ValidationTests: XCTestCase {
     func testValidate() throws {
-        let user = User(name: "Tanner", age: 23, pet: Pet(name: "Zizek Pulaski", age: 4), phone:"1(239)999-7575")
+        let user = User(name: "Tanner", age: 23, pet: Pet(name: "Zizek Pulaski", age: 4), phone:"1 (239)999-7575")
         user.luckyNumber = 7
         user.email = "tanner@vapor.codes"
         try user.validate()
@@ -54,19 +54,19 @@ class ValidationTests: XCTestCase {
     }
 
     func testPhone() throws {
-        try Validator<String>.phone(type: .simple(.plain)).validate("2399997777")
-        try Validator<String>.phone(type: .simple(.dashOnly)).validate("239-999-7777")
-        try Validator<String>.phone(type: .simple(.dashWithParenthesis)).validate("(239)999-7777")
-        try Validator<String>.phone(type: .prefix(.plain)).validate("12399997777")
-        try Validator<String>.phone(type: .prefix(.dashOnly)).validate("72-239-999-7777")
-        try Validator<String>.phone(type: .prefix(.dashWithParenthesis)).validate("99(239)999-7777")
+        try Validator<String>.phone(type: .useSimple(.plain)).validate("2399997777")
+        try Validator<String>.phone(type: .useSimple(.dashOnly)).validate("239-999-7777")
+        try Validator<String>.phone(type: .useSimple(.dashWithParenthesis)).validate("(239)999-7777")
+        try Validator<String>.phone(type: .useCountryCode(.plain)).validate("1 2399997777")
+        try Validator<String>.phone(type: .useCountryCode(.dashOnly)).validate("72 239-999-7777")
+        try Validator<String>.phone(type: .useCountryCode(.dashWithParenthesis)).validate("99 (239)999-7777")
 
-        XCTAssertThrowsError(try Validator<String>.phone(type: .simple(.plain)).validate("23999977777"))
-        XCTAssertThrowsError(try Validator<String>.phone(type: .simple(.dashOnly)).validate("1(239)999-7777"))
-        XCTAssertThrowsError(try Validator<String>.phone(type: .simple(.dashWithParenthesis)).validate("239-999-7777"))
-        XCTAssertThrowsError(try Validator<String>.phone(type: .prefix(.plain)).validate("1239-999-7777"))
-        XCTAssertThrowsError(try Validator<String>.phone(type: .prefix(.dashOnly)).validate("72(239)999-7777"))
-        XCTAssertThrowsError(try Validator<String>.phone(type: .prefix(.dashWithParenthesis)).validate("99-239-999-7777"))
+        XCTAssertThrowsError(try Validator<String>.phone(type: .useSimple(.plain)).validate("23999977777"))
+        XCTAssertThrowsError(try Validator<String>.phone(type: .useSimple(.dashOnly)).validate("1(239)999-7777"))
+        XCTAssertThrowsError(try Validator<String>.phone(type: .useSimple(.dashWithParenthesis)).validate("239-999-7777"))
+        XCTAssertThrowsError(try Validator<String>.phone(type: .useCountryCode(.plain)).validate("1239-999-7777"))
+        XCTAssertThrowsError(try Validator<String>.phone(type: .useCountryCode(.dashOnly)).validate("72(239)999-7777"))
+        XCTAssertThrowsError(try Validator<String>.phone(type: .useCountryCode(.dashWithParenthesis)).validate("99-239-999-777"))
     }
     
     static var allTests = [
@@ -112,7 +112,7 @@ final class User: Validatable, Reflectable, Codable {
         // validate that the lucky number is nil or is 5 or 7
         try validations.add(\.luckyNumber, .nil || .in(5, 7))
         // validate that the phone number format is of the specified format
-        try validations.add(\.phone, .phone(type: .prefix(.dashWithParenthesis)))
+        try validations.add(\.phone, .phone(type: .useCountryCode(.dashWithParenthesis)))
         print(validations)
         return validations
     }

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -54,12 +54,19 @@ class ValidationTests: XCTestCase {
     }
 
     func testPhone() throws {
+
+        let genericInternationalRegex = """
+        ((?:\\+|00)[17](?: |\\-)?|(?:\\+|00)[1-9]\\d{0,2}(?: |\\-)?|(?:\\+|00)1\\-\\d{3}(?: |\\-)?)?(0\\d|\\([0-9]{3}\\)|[1-9]{0,3})(?:((?: |\\-)[0-9]{2}){4}|((?:[0-9]{2}){4})|((?: |\\-)[0-9]{3}(?: |\\-)[0-9]{4})|([0-9]{7}))
+        """
+
         try Validator<String>.phone(type: .useSimple(.plain)).validate("2399997777")
         try Validator<String>.phone(type: .useSimple(.dashOnly)).validate("239-999-7777")
         try Validator<String>.phone(type: .useSimple(.dashWithParenthesis)).validate("(239)999-7777")
         try Validator<String>.phone(type: .useCountryCode(.plain)).validate("1 2399997777")
         try Validator<String>.phone(type: .useCountryCode(.dashOnly)).validate("72 239-999-7777")
         try Validator<String>.phone(type: .useCountryCode(.dashWithParenthesis)).validate("99 (239)999-7777")
+        try Validator<String>.phone(type: .useCustomRegex({ "[0-9]{3}[0-9]{3}[0-9]{4}$" })).validate("2399997777")
+        try Validator<String>.phone(type: .useCustomRegex({ genericInternationalRegex })).validate("+7 06 79 91 25 49")
 
         XCTAssertThrowsError(try Validator<String>.phone(type: .useSimple(.plain)).validate("23999977777"))
         XCTAssertThrowsError(try Validator<String>.phone(type: .useSimple(.dashOnly)).validate("1(239)999-7777"))
@@ -67,6 +74,7 @@ class ValidationTests: XCTestCase {
         XCTAssertThrowsError(try Validator<String>.phone(type: .useCountryCode(.plain)).validate("1239-999-7777"))
         XCTAssertThrowsError(try Validator<String>.phone(type: .useCountryCode(.dashOnly)).validate("72(239)999-7777"))
         XCTAssertThrowsError(try Validator<String>.phone(type: .useCountryCode(.dashWithParenthesis)).validate("99-239-999-777"))
+        XCTAssertThrowsError(try Validator<String>.phone(type: .useCustomRegex({ "" })).validate("72(239)999-7777"))
     }
     
     static var allTests = [


### PR DESCRIPTION
## Reason:

- Adds phone validations for multiple different formats

## Changes:

- Added `PhoneType` and `PhoneFormat` enum.
- PhoneType
    - simple
    - prefix - adds 1(xxx)xxx-xxxx
- PhoneFormat
    - simple - only the numbers `2397775555`
    - dashWithParenthesis - wraps area code in parenthesis and uses dash in-between the phone `(239)7775555`
    - dashOnly - uses only dash in-between sections `239-777-5555`