### PR TITLE
Add emptyness validation

### DIFF
--- a/Sources/Validation/Validators/EmptyValidator.swift
+++ b/Sources/Validation/Validators/EmptyValidator.swift
@@ -1,23 +1,24 @@
-//
-//  EmptyValidator.swift
-//  Validation
-//
-//  Created by Frédéric Ruaudel on 19/07/2018.
-//
-
-import Foundation
-
 extension Validator where T: Collection {
+    /// Validates that the data is empty. You can also check a non empty state by combining with the `NotValidator`
+    ///
+    ///     try validations.add(\.name, .empty)
+    ///     try validations.add(\.name, !.empty)
+    ///
     public static var empty: Validator<T> {
         return EmptyValidator().validator()
     }
 }
 
+// MARK: Private
+
+/// Validates whether the data is empty.
 fileprivate struct EmptyValidator<T>: ValidatorType where T: Collection {
+    /// See `ValidatorType`.
     var validatorReadable: String {
         return "empty"
     }
     
+    /// See `ValidatorType`.
     func validate(_ data: T) throws {
         guard data.isEmpty else {
             throw BasicValidationError("is not empty")

--- a/Sources/Validation/Validators/EmptyValidator.swift
+++ b/Sources/Validation/Validators/EmptyValidator.swift
@@ -1,0 +1,26 @@
+//
+//  EmptyValidator.swift
+//  Validation
+//
+//  Created by Frédéric Ruaudel on 19/07/2018.
+//
+
+import Foundation
+
+extension Validator where T: Collection {
+    public static var empty: Validator<T> {
+        return EmptyValidator().validator()
+    }
+}
+
+fileprivate struct EmptyValidator<T>: ValidatorType where T: Collection {
+    var validatorReadable: String {
+        return "empty"
+    }
+    
+    func validate(_ data: T) throws {
+        guard data.isEmpty else {
+            throw BasicValidationError("is not empty")
+        }
+    }
+}

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class ValidationTests: XCTestCase {
     func testValidate() throws {
-        let user = User(name: "Tanner", age: 23, pet: Pet(name: "Zizek Pulaski", age: 4))
+        let user = User(name: "Tanner", age: 23, pet: Pet(name: "Zizek Pulaski", age: 4), preferedColors: ["blue?", "green?"])
         user.luckyNumber = 7
         user.email = "tanner@vapor.codes"
         try user.validate()
@@ -22,6 +22,13 @@ class ValidationTests: XCTestCase {
     func testAlphanumeric() throws {
         try Validator<String>.alphanumeric.validate("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
         XCTAssertThrowsError(try Validator<String>.alphanumeric.validate("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"))
+    }
+    
+    func testEmpty() throws {
+        try Validator<String>.empty.validate("")
+        XCTAssertThrowsError(try Validator<String>.empty.validate("something"))
+        try Validator<[Int]>.empty.validate([])
+        XCTAssertThrowsError(try Validator<[Int]>.empty.validate([1, 2]))
     }
 
     func testEmail() throws {
@@ -57,6 +64,7 @@ class ValidationTests: XCTestCase {
         ("testValidate", testValidate),
         ("testASCII", testASCII),
         ("testAlphanumeric", testAlphanumeric),
+        ("testEmpty", testEmpty),
         ("testEmail", testEmail),
         ("testRange", testRange),
     ]
@@ -69,12 +77,14 @@ final class User: Validatable, Reflectable, Codable {
     var email: String?
     var pet: Pet
     var luckyNumber: Int?
+    var preferedColors: [String]
 
-    init(id: Int? = nil, name: String, age: Int, pet: Pet) {
+    init(id: Int? = nil, name: String, age: Int, pet: Pet, preferedColors: [String]) {
         self.id = id
         self.name = name
         self.age = age
         self.pet = pet
+        self.preferedColors = preferedColors
     }
 
 
@@ -92,6 +102,7 @@ final class User: Validatable, Reflectable, Codable {
         try validations.add(\.email, .email || .nil) // test other way
         // validate that the lucky number is nil or is 5 or 7
         try validations.add(\.luckyNumber, .nil || .in(5, 7))
+        try validations.add(\.preferedColors, !.empty)
         print(validations)
         return validations
     }


### PR DESCRIPTION
This PR add an emptiness validator with associated documentation and tests. 

I know it can be achieved using the `count` validator but with this one, the error and description is more explicit on what we really want: 

`preferedColors: is not empty` 
`⚠️ [ValidateErrors.validationFailed: 'preferedColors' is empty]`

instead of: 

`preferedColors: is at least 1 items`
`⚠️ [ValidateErrors.validationFailed: 'preferedColors' is not larger than 1]`