### PR TITLE
Adds URLValidator

### DIFF
--- a/Sources/Validation/Validators/URLValidator.swift
+++ b/Sources/Validation/Validators/URLValidator.swift
@@ -26,7 +26,7 @@ fileprivate struct URLValidator: ValidatorType {
         return "a valid URL"
     }
 
-    /// Creates a new `EmailValidator`.
+    /// Creates a new `URLValidator`.
     public init() {}
 
     /// See `Validator`.

--- a/Sources/Validation/Validators/URLValidator.swift
+++ b/Sources/Validation/Validators/URLValidator.swift
@@ -1,0 +1,39 @@
+extension Validator where T == String {
+    /// Validates whether a `String` is a valid URL.
+    ///
+    ///     try validations.add(\.profilePictureURL, .url)
+    ///
+    ///     alternatively, if you want to allow an optional URL:
+    ///
+    ///     try validations.add(\.profilePictureURL, .url || .nil)
+    ///
+    /// This validator will allow either file URLs, or URLs 
+    /// containing at least a scheme and a host.
+    ///
+    public static var url: Validator<T> {
+        return URLValidator().validator()
+    }
+}
+
+// MARK: Private
+
+/// Validates whether a string is a valid email address.
+fileprivate struct URLValidator: ValidatorType {
+    typealias ValidationData = String
+
+    /// See `ValidatorType`.
+    public var validatorReadable: String {
+        return "a valid URL"
+    }
+
+    /// Creates a new `EmailValidator`.
+    public init() {}
+
+    /// See `Validator`.
+    func validate(_ data: String) throws {
+        guard let url = URL(string: data),
+            url.isFileURL || (url.host != nil && url.scheme != nil) else {
+            throw BasicValidationError("is not a valid URL")
+        }
+    }
+}

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -9,6 +9,11 @@ class ValidationTests: XCTestCase {
         user.email = "tanner@vapor.codes"
         try user.validate()
         try user.pet.validate()
+
+        let secondUser = User(name: "Natan", age: 30, pet: Pet(name: "Nina", age: 4))
+        secondUser.profilePictureURL = "https://www.somedomain.com/somePath.png"
+        secondUser.email = "natan@vapor.codes"
+        try secondUser.validate()
     }
 
     func testASCII() throws {
@@ -52,6 +57,14 @@ class ValidationTests: XCTestCase {
         XCTAssertThrowsError(try Validator<Int>.range(-5..<6).validate(-6))
         XCTAssertThrowsError(try Validator<Int>.range(-5..<6).validate(6))
     }
+
+    func testURL() throws {
+        try Validator<String>.url.validate("https://www.somedomain.com/somepath.png")
+        try Validator<String>.url.validate("https://www.somedomain.com/")
+        try Validator<String>.url.validate("file:///Users/vapor/rocks/somePath.png")
+        XCTAssertThrowsError(try Validator<String>.url.validate("www.somedomain.com/"))
+        XCTAssertThrowsError(try Validator<String>.url.validate("bananas"))
+    }
     
     static var allTests = [
         ("testValidate", testValidate),
@@ -59,6 +72,7 @@ class ValidationTests: XCTestCase {
         ("testAlphanumeric", testAlphanumeric),
         ("testEmail", testEmail),
         ("testRange", testRange),
+        ("testURL", testURL),
     ]
 }
 
@@ -69,6 +83,7 @@ final class User: Validatable, Reflectable, Codable {
     var email: String?
     var pet: Pet
     var luckyNumber: Int?
+    var profilePictureURL: String?
 
     init(id: Int? = nil, name: String, age: Int, pet: Pet) {
         self.id = id
@@ -76,7 +91,6 @@ final class User: Validatable, Reflectable, Codable {
         self.age = age
         self.pet = pet
     }
-
 
     static func validations() throws -> Validations<User> {
         var validations = Validations(User.self)
@@ -92,6 +106,8 @@ final class User: Validatable, Reflectable, Codable {
         try validations.add(\.email, .email || .nil) // test other way
         // validate that the lucky number is nil or is 5 or 7
         try validations.add(\.luckyNumber, .nil || .in(5, 7))
+        // validate that the profile picture is nil or a valid URL
+        try validations.add(\.profilePictureURL, .url || .nil)
         print(validations)
         return validations
     }

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -94,7 +94,7 @@ final class User: Validatable, Reflectable, Codable {
     var profilePictureURL: String?
     var preferedColors: [String]
 
-    init(id: Int? = nil, name: String, age: Int, pet: Pet, preferedColors: [String]) {
+    init(id: Int? = nil, name: String, age: Int, pet: Pet, preferedColors: [String] = []) {
         self.id = id
         self.name = name
         self.age = age


### PR DESCRIPTION
This validator will allow either file URLs, or URLs containing at least a scheme and a host.

My initial motivation was adding an optional URL field to one of my Model.
The problem was that using the `URL` type required implementing the `ReflectionDecodable` protocol, and also the result saved in the DB wasn't purely the URL. (It saved as a key value JSON, where the value was the URL). The problem is that setting that field as `bananas` would also succeed.

So I decided to create my own validator - and here I'm contributing to Vapor for the first time.

Initially I wanted to have only `guard let url = URL(string: data) else { ...`, but (to my surprise), initializing a URL with `URL(string: "bananas")` does not return nil. So I decided to check at least for scheme and host, or if it's a file URL.

I hope you like it, and I'm open to improving this. Feel free to edit.

Added tests as well
