### PR TITLE
Critical updates for Swift 4.2, fix warnings

### DIFF
--- a/Sources/Validation/Convenience/Alphanumeric.swift
+++ b/Sources/Validation/Convenience/Alphanumeric.swift
@@ -1,5 +1,9 @@
 private let alphanumeric = "abcdefghijklmnopqrstuvwxyz0123456789"
+#if swift(>=4)
+private let validCharacters = alphanumeric
+#else
 private let validCharacters = alphanumeric.characters
+#endif
 
 /// A validator that can be used to check that a
 /// given string contains only alphanumeric characters
@@ -13,10 +17,17 @@ public struct OnlyAlphanumeric: Validator {
 
         - throws: an error if validation fails
     */
+
+
     public func validate(_ input: String) throws {
-        let passed = !input
-            .lowercased()
-            .characters
+
+    #if swift(>=4)
+        let characters = input.lowercased()
+    #else
+        let characters = input.lowercased().characters
+    #endif
+
+        let passed = !characters
             .contains { !validCharacters.contains($0) }
 
         if !passed {

--- a/Sources/Validation/Convenience/Base64.swift
+++ b/Sources/Validation/Convenience/Base64.swift
@@ -5,7 +5,12 @@ public struct Base64Validator: Validator {
     private let pattern = "^(?:[a-z0-9\\+\\/]{4})*(?:[a-z0-9\\+\\/]{2}==|[a-z0-9\\+\\/]{3}=|[a-z0-9\\+\\/]{4})$"
 
     public func validate(_ input: String) throws {
-        guard input.characters.count % 4 == 0 && input.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil else {
+        #if swift(>=4)
+            let count = input.count
+        #else
+            let count = input.characters.count
+        #endif
+        guard count % 4 == 0 && input.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil else {
             throw error("\(input) is not a valid base64 string")
         }
     }

--- a/Sources/Validation/Convenience/Count.swift
+++ b/Sources/Validation/Convenience/Count.swift
@@ -1,7 +1,7 @@
 /// Indicates that a particular type can be validated by count or length
 public protocol Countable: Validatable {
     // The type that will be used to evaluate the count
-    associatedtype CountType: Comparable, Equatable
+    associatedtype CountType: Comparable
 
     // The count of the object
     var count: CountType { get }
@@ -85,9 +85,12 @@ extension Float: Countable {}
 extension Double: Countable {}
 
 extension String: Countable {
+    #if swift(>=4)
+    #else
     public var count: Int {
         return characters.count
     }
+    #endif
 }
 
 #if swift(>=4)


### PR DESCRIPTION
If Validation (or any package depending on it) is imported, the project won't build if you are using `String().count`: `Ambiguous use of 'count'`

- Fixes `Ambiguous use of 'count'` issue (String)
- Removes `Equatable` protocol from `CountType` (implied by `Comparable`)