### PR TITLE
Use better error messages for RangeValidator and CountValidator

### DIFF
--- a/Sources/Validation/Validators/CountValidator.swift
+++ b/Sources/Validation/Validators/CountValidator.swift
@@ -38,19 +38,12 @@ extension Validator where T: Collection {
 fileprivate struct CountValidator<T>: ValidatorType where T: Collection {
     /// See `ValidatorType`.
     var validatorReadable: String {
-        let x: String
-        if T.self is String.Type {
-            x = "characters"
-        } else {
-            x = "items"
-        }
-
         if let min = self.min, let max = self.max {
-            return "between \(min) and \(max) \(x)"
+            return "between \(min) and \(elementDescription(count: max))"
         } else if let min = self.min {
-            return "at least \(min) \(x)"
+            return "at least \(elementDescription(count: min))"
         } else if let max = self.max {
-            return "at most \(max) \(x)"
+            return "at most \(elementDescription(count: max))"
         } else {
             return "valid"
         }
@@ -75,14 +68,22 @@ fileprivate struct CountValidator<T>: ValidatorType where T: Collection {
     func validate(_ data: T) throws {
         if let min = self.min {
             guard data.count >= min else {
-                throw BasicValidationError("is not larger than \(min)")
+                throw BasicValidationError("is shorter than \(elementDescription(count: min))")
             }
         }
 
         if let max = self.max {
             guard data.count <= max else {
-                throw BasicValidationError("is larger than \(max)")
+                throw BasicValidationError("is longer than \(elementDescription(count: max))")
             }
+        }
+    }
+
+    private func elementDescription(count: Int) -> String {
+        if T.Element.self is Character.Type {
+            return count == 1 ? "1 character" : "\(count) characters"
+        } else {
+            return count == 1 ? "1 item" : "\(count) items"
         }
     }
 }

--- a/Sources/Validation/Validators/CountValidator.swift
+++ b/Sources/Validation/Validators/CountValidator.swift
@@ -68,13 +68,13 @@ fileprivate struct CountValidator<T>: ValidatorType where T: Collection {
     func validate(_ data: T) throws {
         if let min = self.min {
             guard data.count >= min else {
-                throw BasicValidationError("is shorter than \(elementDescription(count: min))")
+                throw BasicValidationError("is less than required minimum of \(elementDescription(count: min))")
             }
         }
 
         if let max = self.max {
             guard data.count <= max else {
-                throw BasicValidationError("is longer than \(elementDescription(count: max))")
+                throw BasicValidationError("is greater than required maximum of \(elementDescription(count: max))")
             }
         }
     }

--- a/Sources/Validation/Validators/RangeValidator.swift
+++ b/Sources/Validation/Validators/RangeValidator.swift
@@ -70,13 +70,13 @@ fileprivate struct RangeValidator<T>: ValidatorType where T: Comparable {
     func validate(_ data: T) throws {
         if let min = self.min {
             guard data >= min else {
-                throw BasicValidationError("is not larger than \(min)")
+                throw BasicValidationError("is less than \(min)")
             }
         }
 
         if let max = self.max {
             guard data <= max else {
-                throw BasicValidationError("is larger than \(max)")
+                throw BasicValidationError("is greater than \(max)")
             }
         }
     }

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -50,19 +50,46 @@ class ValidationTests: XCTestCase {
         try Validator<Int>.range(-5...5).validate(4)
         try Validator<Int>.range(-5...5).validate(5)
         try Validator<Int>.range(-5...5).validate(-5)
-        XCTAssertThrowsError(try Validator<Int>.range(-5...5).validate(6))
-        XCTAssertThrowsError(try Validator<Int>.range(-5...5).validate(-6))
+        XCTAssertThrowsError(try Validator<Int>.range(-5...5).validate(6)) { error in
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is greater than 5")
+        }
+        XCTAssertThrowsError(try Validator<Int>.range(-5...5).validate(-6)) { error in
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is less than -5")
+        }
 
         try Validator<Int>.range(5...).validate(.max)
 
-        try Validator<Int>.range(-5...5).validate(4)
-        XCTAssertThrowsError(try Validator<Int>.range(-5...5).validate(6))
-        
         try Validator<Int>.range(-5..<6).validate(-5)
         try Validator<Int>.range(-5..<6).validate(-4)
         try Validator<Int>.range(-5..<6).validate(5)
         XCTAssertThrowsError(try Validator<Int>.range(-5..<6).validate(-6))
         XCTAssertThrowsError(try Validator<Int>.range(-5..<6).validate(6))
+    }
+
+    func testCountCharacters() throws {
+        let validator = Validator<String>.count(1...6)
+        try validator.validate("1")
+        try validator.validate("123")
+        try validator.validate("123456")
+        XCTAssertThrowsError(try validator.validate("")) { error in
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is shorter than 1 character")
+        }
+        XCTAssertThrowsError(try validator.validate("1234567")) { error in
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is longer than 6 characters")
+        }
+    }
+
+    func testCountItems() throws {
+        let validator = Validator<[Int]>.count(1...6)
+        try validator.validate([1])
+        try validator.validate([1, 2, 3])
+        try validator.validate([1, 2, 3, 4, 5, 6])
+        XCTAssertThrowsError(try validator.validate([])) { error in
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is shorter than 1 item")
+        }
+        XCTAssertThrowsError(try validator.validate([1, 2, 3, 4, 5, 6, 7])) { error in
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is longer than 6 items")
+        }
     }
 
     func testURL() throws {
@@ -80,6 +107,8 @@ class ValidationTests: XCTestCase {
         ("testEmpty", testEmpty),
         ("testEmail", testEmail),
         ("testRange", testRange),
+        ("testCountCharacters", testCountCharacters),
+        ("testCountItems", testCountItems),
         ("testURL", testURL),
     ]
 }

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -72,10 +72,10 @@ class ValidationTests: XCTestCase {
         try validator.validate("123")
         try validator.validate("123456")
         XCTAssertThrowsError(try validator.validate("")) { error in
-            XCTAssertEqual((error as? ValidationError)?.reason, "data is shorter than 1 character")
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is less than required minimum of 1 character")
         }
         XCTAssertThrowsError(try validator.validate("1234567")) { error in
-            XCTAssertEqual((error as? ValidationError)?.reason, "data is longer than 6 characters")
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is greater than required maximum of 6 characters")
         }
     }
 
@@ -85,10 +85,10 @@ class ValidationTests: XCTestCase {
         try validator.validate([1, 2, 3])
         try validator.validate([1, 2, 3, 4, 5, 6])
         XCTAssertThrowsError(try validator.validate([])) { error in
-            XCTAssertEqual((error as? ValidationError)?.reason, "data is shorter than 1 item")
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is less than required minimum of 1 item")
         }
         XCTAssertThrowsError(try validator.validate([1, 2, 3, 4, 5, 6, 7])) { error in
-            XCTAssertEqual((error as? ValidationError)?.reason, "data is longer than 6 items")
+            XCTAssertEqual((error as? ValidationError)?.reason, "data is greater than required maximum of 6 items")
         }
     }
 


### PR DESCRIPTION
"is not larger than X" is replaced with:
* "is less than X"
* "is shorter than X characters"
* "is shorter than X items"

"is larger than X" is replaced with:
* "is greater than X"
* "is longer than X characters"
* "is longer than X items"