### PR TITLE
Make error validation details public, and option to customise the error message

### DIFF
--- a/Sources/Validation/ValidationError.swift
+++ b/Sources/Validation/ValidationError.swift
@@ -7,6 +7,7 @@ import Debugging
 public protocol ValidationError: Debuggable {
     /// Key path to the invalid data.
     var path: [String] { get set }
+    var customMessage: String? { get set }
 }
 
 extension ValidationError {
@@ -22,13 +23,17 @@ extension ValidationError {
 public struct BasicValidationError: ValidationError {
     /// See `Debuggable`
     public var reason: String {
-        let path: String
-        if self.path.count > 0 {
-            path = "'" + self.path.joined(separator: ".") + "'"
+        if let customMessage = customMessage {
+            return customMessage
         } else {
-            path = "data"
+            let path: String
+            if self.path.count > 0 {
+                path = "'" + self.path.joined(separator: ".") + "'"
+            } else {
+                path = "data"
+            }
+            return "\(path) \(message)"
         }
-        return "\(path) \(message)"
     }
 
     /// The validation failure
@@ -36,6 +41,9 @@ public struct BasicValidationError: ValidationError {
 
     /// Key path the validation error happened at
     public var path: [String]
+    
+    /// See ValidationError.customMessage
+    public var customMessage: String?
 
     /// Create a new JWT error
     public init(_ message: String) {

--- a/Sources/Validation/Validations.swift
+++ b/Sources/Validation/Validations.swift
@@ -21,8 +21,9 @@ public struct Validations<M>: CustomStringConvertible where M: Validatable {
     ///     - keyPath: `KeyPath` to validatable property.
     ///     - path: Readable path. Will be displayed when showing errors.
     ///     - validation: `Validation` to run on this property.
-    public mutating func add<T>(_ keyPath: KeyPath<M, T>, at path: [String], _ validator: Validator<T>) {
-        add(keyPath, at: path, "is " + validator.readable, { value in
+    ///     - customMessage: Custom error message.
+    public mutating func add<T>(_ keyPath: KeyPath<M, T>, at path: [String], _ validator: Validator<T>, customMessage: String? = nil) {
+        add(keyPath, at: path, "is " + validator.readable, customMessage: customMessage, { value in
             try validator.validate(value)
         })
     }
@@ -37,13 +38,15 @@ public struct Validations<M>: CustomStringConvertible where M: Validatable {
     ///     - keyPath: `KeyPath` to validatable property.
     ///     - path: Readable path. Will be displayed when showing errors.
     ///     - readable: Readable string describing this validation.
+    ///     - customMessage: Custom error message.
     ///     - custom: Closure accepting the `KeyPath`'s value. Throw a `ValidationError` here if the data is invalid.
-    public mutating func add<T>(_ keyPath: KeyPath<M, T>, at path: [String], _ readable: String, _ custom: @escaping (T) throws -> Void) {
+    public mutating func add<T>(_ keyPath: KeyPath<M, T>, at path: [String], _ readable: String, customMessage: String? = nil, _ custom: @escaping (T) throws -> Void) {
         add("\(path.joined(separator: ".")): \(readable)") { model in
             do {
                 try custom(model[keyPath: keyPath])
             } catch var error as ValidationError {
                 error.path += path
+                error.customMessage = customMessage
                 throw error
             }
         }
@@ -91,8 +94,9 @@ extension Validations where M: Reflectable {
     /// - parameters:
     ///     - keyPath: `KeyPath` to validatable property.
     ///     - validation: `Validation` to run on this property.
-    public mutating func add<T>(_ keyPath: KeyPath<M, T>, _ validator: Validator<T>) throws {
-        try add(keyPath, at: M.reflectProperty(forKey: keyPath)?.path ?? [], validator)
+    ///     - customMessage: Custom error message.
+    public mutating func add<T>(_ keyPath: KeyPath<M, T>, _ validator: Validator<T>, customMessage: String? = nil) throws {
+        try add(keyPath, at: M.reflectProperty(forKey: keyPath)?.path ?? [], validator, customMessage: customMessage)
     }
 
 
@@ -105,9 +109,10 @@ extension Validations where M: Reflectable {
     /// - parameters:
     ///     - keyPath: `KeyPath` to validatable property.
     ///     - readable: Readable string describing this validation.
+    ///     - customMessage: Custom error message.
     ///     - custom: Closure accepting the `KeyPath`'s value. Throw a `ValidationError` here if the data is invalid.
-    public mutating func add<T>(_ keyPath: KeyPath<M, T>, _ readable: String, _ custom: @escaping (T) throws -> Void) throws {
-        try add(keyPath, at: M.reflectProperty(forKey: keyPath)?.path ?? [], readable, custom)
+    public mutating func add<T>(_ keyPath: KeyPath<M, T>, _ readable: String, customMessage: String? = nil, _ custom: @escaping (T) throws -> Void) throws {
+        try add(keyPath, at: M.reflectProperty(forKey: keyPath)?.path ?? [], readable, customMessage: customMessage, custom)
     }
 }
 
@@ -120,6 +125,9 @@ public struct ValidateErrors: ValidationError {
 
     /// See ValidationError.keyPath
     public var path: [String]
+    
+    /// See ValidationError.customMessage
+    public var customMessage: String?
 
     /// See ValidationError.reason
     public var reason: String {

--- a/Sources/Validation/Validations.swift
+++ b/Sources/Validation/Validations.swift
@@ -114,15 +114,15 @@ extension Validations where M: Reflectable {
 // MARK: Private
 
 /// A collection of errors thrown by validatable models validations
-fileprivate struct ValidateErrors: ValidationError {
+public struct ValidateErrors: ValidationError {
     /// the errors thrown
-    var errors: [ValidationError]
+    public var errors: [ValidationError]
 
     /// See ValidationError.keyPath
-    var path: [String]
+    public var path: [String]
 
     /// See ValidationError.reason
-    var reason: String {
+    public var reason: String {
         return errors.map { error in
             var mutableError = error
             mutableError.path = path + error.path

--- a/Sources/Validation/Validators/AndValidator.swift
+++ b/Sources/Validation/Validators/AndValidator.swift
@@ -77,6 +77,9 @@ public struct AndValidatorError: ValidationError {
 
     /// See ValidationError.keyPath
     public var path: [String]
+    
+    /// See ValidationError.customMessage
+    public var customMessage: String?
 
     /// Creates a new or validator error
     init(_ left: ValidationError?, _ right: ValidationError?) {

--- a/Sources/Validation/Validators/AndValidator.swift
+++ b/Sources/Validation/Validators/AndValidator.swift
@@ -48,15 +48,15 @@ fileprivate struct AndValidator<T>: ValidatorType {
 }
 
 /// Error thrown if and validation fails
-fileprivate struct AndValidatorError: ValidationError {
+public struct AndValidatorError: ValidationError {
     /// error thrown by left validator
-    let left: ValidationError?
+    public let left: ValidationError?
 
     /// error thrown by right validator
-    let right: ValidationError?
+    public let right: ValidationError?
 
     /// See ValidationError.reason
-    var reason: String {
+    public var reason: String {
         if let left = left, let right = right {
             var mutableLeft = left, mutableRight = right
             mutableLeft.path = path + left.path
@@ -76,7 +76,7 @@ fileprivate struct AndValidatorError: ValidationError {
     }
 
     /// See ValidationError.keyPath
-    var path: [String]
+    public var path: [String]
 
     /// Creates a new or validator error
     init(_ left: ValidationError?, _ right: ValidationError?) {

--- a/Sources/Validation/Validators/OrValidator.swift
+++ b/Sources/Validation/Validators/OrValidator.swift
@@ -61,6 +61,9 @@ public struct OrValidatorError: ValidationError {
 
     /// See ValidationError.keyPath
     public var path: [String]
+    
+    /// See ValidationError.customMessage
+    public var customMessage: String?
 
     /// Creates a new or validator error
     init(_ left: ValidationError, _ right: ValidationError) {

--- a/Sources/Validation/Validators/OrValidator.swift
+++ b/Sources/Validation/Validators/OrValidator.swift
@@ -43,15 +43,15 @@ fileprivate struct OrValidator<T>: ValidatorType {
 }
 
 /// Error thrown if or validation fails
-fileprivate struct OrValidatorError: ValidationError {
+public struct OrValidatorError: ValidationError {
     /// error thrown by left validator
-    let left: ValidationError
+    public let left: ValidationError
 
     /// error thrown by right validator
-    let right: ValidationError
+    public let right: ValidationError
 
     /// See ValidationError.reason
-    var reason: String {
+    public var reason: String {
         var left = self.left
         left.path = self.path + self.left.path
         var right = self.right
@@ -60,7 +60,7 @@ fileprivate struct OrValidatorError: ValidationError {
     }
 
     /// See ValidationError.keyPath
-    var path: [String]
+    public var path: [String]
 
     /// Creates a new or validator error
     init(_ left: ValidationError, _ right: ValidationError) {


### PR DESCRIPTION
Building a CMS with many forms and many fields, I wanted to be able to get the details of each errors, and the ability to customise the error message per field.
This could fix/help #22, #23, and #26.