### PR TITLE
Ensure whole string is valid email

### DIFF
--- a/Sources/Validation/Convenience/Email.swift
+++ b/Sources/Validation/Convenience/Email.swift
@@ -3,11 +3,14 @@ import Foundation
 public struct EmailValidator: Validator {
 
     public init() {}
-	private let pattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+	private let pattern = "[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,64}"
 
 
     public func validate(_ input: String) throws {
-    	guard input.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil else {
+    	guard
+            let range = input.range(of: pattern, options: [.regularExpression, .caseInsensitive]),
+            range.lowerBound == input.startIndex, range.upperBound == input.endIndex
+        else {
 			throw error("\(input) is not a valid email address")
 		}
     }

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -84,9 +84,11 @@ class ValidationTests: XCTestCase {
         XCTAssertTrue("f@b.co".passes(EmailValidator()))
         XCTAssertTrue("foo@bar.com".passes(EmailValidator()))
         XCTAssertTrue("SOMETHING@SOMETHING.SOMETHING".passes(EmailValidator()))
-        XCTAssertTrue("foo!-bar!-baz@foo.bar".passes(EmailValidator()))
+        XCTAssertTrue("foo-bar-baz@foo.bar".passes(EmailValidator()))
         XCTAssertFalse("f@b.".passes(EmailValidator()))
         XCTAssertFalse("æøå@gmail.com".passes(EmailValidator()))
+        XCTAssertFalse(">a@b.co".passes(EmailValidator()))
+        XCTAssertFalse("a@b.co<".passes(EmailValidator()))
     }
 
     func testValidHexadecimal() {


### PR DESCRIPTION
This is by no means a complete email validator but at least it will now reject strings which contain a valid email but have invalid characters before or after.